### PR TITLE
Added verb_pos option for verb part-of-speech distributions by frame

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 *.pyo
+.DS_Store
+*/.DS_Store

--- a/lexvars/bnc_word_vecs.py
+++ b/lexvars/bnc_word_vecs.py
@@ -120,13 +120,17 @@ class BNCWordVecs(object):
                 if is_context_word[j]:
                     self.vectors[words[i]][words[j]] += 1
 
-    def process_bigrams(self, words, verbs_only=False, lemma_pos=None):
+    def process_bigrams(self, words, verbs_only=False, lemma_pos=None, which_word='first'):
         is_verb = [x == VERB for x in lemma_pos]
         for i in range(len(words)-1):
             if words[i] not in self.target_words or (verbs_only and not is_verb[i]):
                 continue
-            self.vectors[words[i]].setdefault(words[i+1], 0)
-            self.vectors[words[i]][words[i+1]] += 1
+            if which_word == 'first':
+                self.vectors[words[i]].setdefault(words[i+1], 0)
+                self.vectors[words[i]][words[i+1]] += 1
+            elif which_word == 'second':
+                self.vectors[words[i]].setdefault(words[i-1], 0)
+                self.vectors[words[i]][words[i-1]] += 1
 
     def all_files(self):
         for f1 in os.listdir(self.corpus_root):
@@ -184,7 +188,7 @@ class BNCWordVecs(object):
                     ent += term
             self.entropies[w] = ent
 
-    def read_all(self, process=False, bigrams=False, verbs_only=False):
+    def read_all(self, process=False, bigrams=False, verbs_only=False, which_word='first'):
         self.total_n_words = 0
         if process:
             self.initialize_matrix(bigrams=bigrams)
@@ -194,7 +198,7 @@ class BNCWordVecs(object):
                 if not bigrams:
                     self.process(words)
                 elif bigrams:
-                    self.process_bigrams(words, verbs_only=verbs_only, lemma_pos=pos)
+                    self.process_bigrams(words, verbs_only=verbs_only, lemma_pos=pos, which_word=which_word)
 
     def save_context_words(self, filename):
         common = self.frequencies.most_common(self.n_context_words)


### PR DESCRIPTION
When the _verb_pos_ option is true, each entry for a given verb and frame will include a key "pos" whose value is a dictionary with the verb's part-of-speech tags and their counts in that frame.

For some reason this makes `Valex.load_all_verbs()` take 20 minutes instead of several seconds; I think it's due to the additional regular expression, so you might want to take a look at it. Other than that it works at least for my purposes.
